### PR TITLE
Voeg KLAAR knoppie by meds en water skerms

### DIFF
--- a/app/lib/screens/meds_screen.dart
+++ b/app/lib/screens/meds_screen.dart
@@ -174,6 +174,11 @@ class MedsScreen extends ConsumerWidget {
                         ),
                         const SizedBox(height: 16),
                         PhotoCaptureButton(module: 'meds', session: session),
+                        const SizedBox(height: 16),
+                        FilledButton(
+                          onPressed: () => context.go('/'),
+                          child: const Text('KLAAR'),
+                        ),
                         if (canUndo) ...[
                           const SizedBox(height: 16),
                           TextButton(

--- a/app/lib/screens/water_screen.dart
+++ b/app/lib/screens/water_screen.dart
@@ -97,6 +97,11 @@ class WaterScreen extends ConsumerWidget {
                   ),
                   const SizedBox(height: 16),
                   const PhotoCaptureButton(module: 'water', compact: true),
+                  const SizedBox(height: 16),
+                  FilledButton(
+                    onPressed: () => context.go('/'),
+                    child: const Text('KLAAR'),
+                  ),
                 ],
                 const Spacer(flex: 2),
               ],


### PR DESCRIPTION
## Summary
- Add "KLAAR" `FilledButton` to meds confirmation screen (after photo capture)
- Add "KLAAR" `FilledButton` to water screen (after photo capture)
- All 4 health modules (BP, walk, meds, water) now consistently have a prominent home button

closes #4

## Test plan
- [ ] Open meds screen, confirm morning meds → verify "KLAAR" button appears and navigates home
- [ ] Open meds screen, confirm night meds → same check
- [ ] Open water screen → verify "KLAAR" button appears and navigates home
- [ ] Verify BP and walk screens still have their "KLAAR" buttons (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)