### PR TITLE
feat: implement /summary endpoint

### DIFF
--- a/backend/routes/summary.dart
+++ b/backend/routes/summary.dart
@@ -1,20 +1,118 @@
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:drift/drift.dart';
+import 'package:sorgvry_backend/middleware/auth.dart';
+import 'package:sorgvry_shared/sorgvry_shared.dart';
+
+/// B12 injection start date per spec (section 10).
+final _b12StartDate = DateTime(2026, 3, 27);
+
+/// Returns true if [date] falls on a B12 injection day (every 14 days).
+bool _isB12Day(DateTime date) {
+  final diff = date.difference(_b12StartDate).inDays;
+  return diff >= 0 && diff % 14 == 0;
+}
+
+/// Formats a [DateTime] as "HH:mm" (24-hour).
+String _timeOf(DateTime dt) =>
+    '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
 
 Future<Response> onRequest(RequestContext context) async {
   if (context.request.method != HttpMethod.get) {
     return Response(statusCode: HttpStatus.methodNotAllowed);
   }
 
-  // TODO: implement daily summary query
-  return Response.json(
-    body: <String, dynamic>{
-      'date': null,
-      'meds': <String, dynamic>{},
-      'bp': <String, dynamic>{},
-      'water': <String, dynamic>{},
-      'walk': <String, dynamic>{},
-    },
-  );
+  try {
+    final db = context.read<SorgvryDatabase>();
+    final deviceId = context.read<AuthenticatedDeviceId>().value;
+
+    // Parse date query parameter, default to today (midnight-normalised).
+    final dateParam = context.request.uri.queryParameters['date'];
+    final date = dateParam != null ? DateTime.parse(dateParam) : DateTime.now();
+    final normalised = DateTime(date.year, date.month, date.day);
+
+    // --- Meds ---
+    final medRows =
+        await (db.select(db.medLogs)..where(
+              (t) => t.deviceId.equals(deviceId) & t.date.equals(normalised),
+            ))
+            .get();
+
+    final medsMap = <String, Map<String, dynamic>>{};
+    for (final session in ['morning', 'night']) {
+      final row = medRows.where((r) => r.session == session).firstOrNull;
+      medsMap[session] = row != null
+          ? {'taken': row.taken, 'at': row.taken ? _timeOf(row.loggedAt) : null}
+          : {'taken': false, 'at': null};
+    }
+    // B12: include due flag, plus taken if logged.
+    final b12Row = medRows.where((r) => r.session == 'b12').firstOrNull;
+    medsMap['b12'] = {
+      'due': _isB12Day(normalised),
+      'taken': b12Row?.taken ?? false,
+    };
+
+    // --- Blood pressure ---
+    final bpRow =
+        await (db.select(db.bpReadings)..where(
+              (t) => t.deviceId.equals(deviceId) & t.date.equals(normalised),
+            ))
+            .getSingleOrNull();
+
+    final bpMap = bpRow != null
+        ? <String, dynamic>{
+            'systolic': bpRow.systolic,
+            'diastolic': bpRow.diastolic,
+            'map': bpRow.meanArterialPressure,
+            'at': _timeOf(bpRow.loggedAt),
+          }
+        : <String, dynamic>{};
+
+    // --- Water ---
+    final waterRow =
+        await (db.select(db.waterLogs)..where(
+              (t) => t.deviceId.equals(deviceId) & t.date.equals(normalised),
+            ))
+            .getSingleOrNull();
+
+    final waterMap = waterRow != null
+        ? <String, dynamic>{'glasses': waterRow.glasses}
+        : <String, dynamic>{};
+
+    // --- Walk ---
+    final walkRow =
+        await (db.select(db.walkLogs)..where(
+              (t) => t.deviceId.equals(deviceId) & t.date.equals(normalised),
+            ))
+            .getSingleOrNull();
+
+    final walkMap = walkRow != null
+        ? <String, dynamic>{
+            'walked': walkRow.walked,
+            'durationMin': walkRow.durationMin,
+          }
+        : <String, dynamic>{};
+
+    return Response.json(
+      body: <String, dynamic>{
+        'date':
+            '${normalised.year}-${normalised.month.toString().padLeft(2, '0')}-${normalised.day.toString().padLeft(2, '0')}',
+        'meds': medsMap,
+        'bp': bpMap,
+        'water': waterMap,
+        'walk': walkMap,
+      },
+    );
+  } on FormatException {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: <String, dynamic>{'error': 'Invalid date format'},
+    );
+  } catch (_) {
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: <String, dynamic>{'error': 'Internal server error'},
+    );
+  }
 }

--- a/backend/test/routes/summary_test.dart
+++ b/backend/test/routes/summary_test.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sorgvry_backend/middleware/auth.dart';
+import 'package:sorgvry_shared/sorgvry_shared.dart';
+import 'package:test/test.dart';
+
+import '../../routes/summary.dart' as route;
+
+class _MockRequestContext extends Mock implements RequestContext {}
+
+class _MockRequest extends Mock implements Request {}
+
+void main() {
+  late SorgvryDatabase db;
+  const deviceId = 'test-device-001';
+
+  setUp(() {
+    db = SorgvryDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  RequestContext buildContext({String? date}) {
+    final ctx = _MockRequestContext();
+    final request = _MockRequest();
+
+    final queryParams = <String, String>{};
+    if (date != null) queryParams['date'] = date;
+    final uri = Uri.http('localhost', '/summary', queryParams);
+
+    when(() => request.method).thenReturn(HttpMethod.get);
+    when(() => request.uri).thenReturn(uri);
+    when(() => ctx.request).thenReturn(request);
+    when(() => ctx.read<SorgvryDatabase>()).thenReturn(db);
+    when(
+      () => ctx.read<AuthenticatedDeviceId>(),
+    ).thenReturn(const AuthenticatedDeviceId(deviceId));
+
+    return ctx;
+  }
+
+  group('GET /summary', () {
+    test('returns empty data for a date with no records', () async {
+      final ctx = buildContext(date: '2026-04-01');
+      final response = await route.onRequest(ctx);
+
+      expect(response.statusCode, HttpStatus.ok);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['date'], '2026-04-01');
+      expect(body['meds']['morning'], {'taken': false, 'at': null});
+      expect(body['meds']['night'], {'taken': false, 'at': null});
+      expect(body['meds']['b12']['taken'], false);
+      expect(body['bp'], isEmpty);
+      expect(body['water'], isEmpty);
+      expect(body['walk'], isEmpty);
+    });
+
+    test('returns meds data when morning and night are logged', () async {
+      final date = DateTime(2026, 4, 1);
+      await db
+          .into(db.medLogs)
+          .insert(
+            MedLogsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              session: const Value('morning'),
+              taken: const Value(true),
+              loggedAt: Value(DateTime(2026, 4, 1, 7, 14)),
+              synced: const Value(true),
+            ),
+          );
+      await db
+          .into(db.medLogs)
+          .insert(
+            MedLogsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              session: const Value('night'),
+              taken: const Value(true),
+              loggedAt: Value(DateTime(2026, 4, 1, 20, 30)),
+              synced: const Value(true),
+            ),
+          );
+
+      final ctx = buildContext(date: '2026-04-01');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['meds']['morning'], {'taken': true, 'at': '07:14'});
+      expect(body['meds']['night'], {'taken': true, 'at': '20:30'});
+    });
+
+    test('returns BP reading when logged', () async {
+      final date = DateTime(2026, 4, 1);
+      await db
+          .into(db.bpReadings)
+          .insert(
+            BpReadingsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              systolic: const Value(148),
+              diastolic: const Value(88),
+              meanArterialPressure: const Value(108.0),
+              loggedAt: Value(DateTime(2026, 4, 1, 8, 32)),
+              synced: const Value(true),
+            ),
+          );
+
+      final ctx = buildContext(date: '2026-04-01');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['bp']['systolic'], 148);
+      expect(body['bp']['diastolic'], 88);
+      expect(body['bp']['map'], 108.0);
+      expect(body['bp']['at'], '08:32');
+    });
+
+    test('returns water and walk data when logged', () async {
+      final date = DateTime(2026, 4, 1);
+      await db
+          .into(db.waterLogs)
+          .insert(
+            WaterLogsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              glasses: const Value(5),
+              loggedAt: Value(date),
+              synced: const Value(true),
+            ),
+          );
+      await db
+          .into(db.walkLogs)
+          .insert(
+            WalkLogsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              walked: const Value(true),
+              durationMin: const Value(30),
+              loggedAt: Value(date),
+              synced: const Value(true),
+            ),
+          );
+
+      final ctx = buildContext(date: '2026-04-01');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['water'], {'glasses': 5});
+      expect(body['walk'], {'walked': true, 'durationMin': 30});
+    });
+
+    test('B12 due is true on injection day (start date)', () async {
+      // 27 March 2026 is the B12 start date.
+      final ctx = buildContext(date: '2026-03-27');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['meds']['b12']['due'], true);
+    });
+
+    test('B12 due is true 14 days after start', () async {
+      // 27 March + 14 = 10 April 2026
+      final ctx = buildContext(date: '2026-04-10');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['meds']['b12']['due'], true);
+    });
+
+    test('B12 taken is true when logged on injection day', () async {
+      final date = DateTime(2026, 3, 27);
+      await db
+          .into(db.medLogs)
+          .insert(
+            MedLogsCompanion(
+              deviceId: const Value(deviceId),
+              date: Value(date),
+              session: const Value('b12'),
+              taken: const Value(true),
+              loggedAt: Value(DateTime(2026, 3, 27, 9, 0)),
+              synced: const Value(true),
+            ),
+          );
+
+      final ctx = buildContext(date: '2026-03-27');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['meds']['b12']['due'], true);
+      expect(body['meds']['b12']['taken'], true);
+    });
+
+    test('B12 due is false on non-injection day', () async {
+      final ctx = buildContext(date: '2026-04-01');
+      final response = await route.onRequest(ctx);
+      final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+
+      expect(body['meds']['b12']['due'], false);
+    });
+
+    test('returns 400 for invalid date format', () async {
+      final ctx = buildContext(date: 'not-a-date');
+      final response = await route.onRequest(ctx);
+
+      expect(response.statusCode, HttpStatus.badRequest);
+    });
+
+    test('rejects non-GET methods', () async {
+      final ctx = _MockRequestContext();
+      final request = _MockRequest();
+      when(() => request.method).thenReturn(HttpMethod.post);
+      when(() => ctx.request).thenReturn(request);
+
+      final response = await route.onRequest(ctx);
+      expect(response.statusCode, HttpStatus.methodNotAllowed);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implement `GET /summary?date=YYYY-MM-DD` endpoint (was a TODO stub)
- Query meds (morning/night/b12), BP, water, and walk records for a device + date
- B12 `due` field calculated every 14 days from 27 March 2026 (per spec section 10)
- Empty objects `{}` returned for missing BP/water/walk data
- 400 error for invalid date format, generic catch for unexpected errors
- 11 tests with in-memory SQLite covering all data paths, B12 logic, and error handling

closes #10

## Test plan
- [x] `dart test` — 11/11 pass (9 summary + 1 index + 1 B12 taken)
- [x] `dart analyze` — zero issues on source file
- [x] `dart format` — no changes needed
- [ ] Manual: `curl -H "Authorization: Bearer <token>" https://sorgvry.phygital-tech.ai/api/summary?date=2026-03-29` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)