### PR TITLE
fix: normalise dates to UTC midnight in all /log/* endpoints

### DIFF
--- a/backend/routes/log/bp.dart
+++ b/backend/routes/log/bp.dart
@@ -16,9 +16,16 @@ Future<Response> onRequest(RequestContext context) async {
     final body = await context.request.json() as Map<String, dynamic>;
     final request = BpReadingRequest.fromJson(body);
 
+    final parsedDate = DateTime.parse(request.date);
+    final normalisedDate = DateTime.utc(
+      parsedDate.year,
+      parsedDate.month,
+      parsedDate.day,
+    );
+
     final entry = BpReadingsCompanion(
       deviceId: Value(deviceId),
-      date: Value(DateTime.parse(request.date)),
+      date: Value(normalisedDate),
       systolic: Value(request.systolic),
       diastolic: Value(request.diastolic),
       meanArterialPressure: Value(request.map),

--- a/backend/routes/log/meds.dart
+++ b/backend/routes/log/meds.dart
@@ -16,9 +16,16 @@ Future<Response> onRequest(RequestContext context) async {
     final body = await context.request.json() as Map<String, dynamic>;
     final request = MedLogRequest.fromJson(body);
 
+    final parsedDate = DateTime.parse(request.date);
+    final normalisedDate = DateTime.utc(
+      parsedDate.year,
+      parsedDate.month,
+      parsedDate.day,
+    );
+
     final entry = MedLogsCompanion(
       deviceId: Value(deviceId),
-      date: Value(DateTime.parse(request.date)),
+      date: Value(normalisedDate),
       session: Value(request.session),
       taken: Value(request.taken),
       loggedAt: Value(DateTime.parse(request.loggedAt)),

--- a/backend/routes/log/walk.dart
+++ b/backend/routes/log/walk.dart
@@ -16,9 +16,16 @@ Future<Response> onRequest(RequestContext context) async {
     final body = await context.request.json() as Map<String, dynamic>;
     final request = WalkLogRequest.fromJson(body);
 
+    final parsedDate = DateTime.parse(request.date);
+    final normalisedDate = DateTime.utc(
+      parsedDate.year,
+      parsedDate.month,
+      parsedDate.day,
+    );
+
     final entry = WalkLogsCompanion(
       deviceId: Value(deviceId),
-      date: Value(DateTime.parse(request.date)),
+      date: Value(normalisedDate),
       walked: Value(request.walked),
       durationMin: Value(request.durationMin),
       loggedAt: Value(DateTime.parse(request.loggedAt)),

--- a/backend/routes/log/water.dart
+++ b/backend/routes/log/water.dart
@@ -16,9 +16,16 @@ Future<Response> onRequest(RequestContext context) async {
     final body = await context.request.json() as Map<String, dynamic>;
     final request = WaterLogRequest.fromJson(body);
 
+    final parsedDate = DateTime.parse(request.date);
+    final normalisedDate = DateTime.utc(
+      parsedDate.year,
+      parsedDate.month,
+      parsedDate.day,
+    );
+
     final entry = WaterLogsCompanion(
       deviceId: Value(deviceId),
-      date: Value(DateTime.parse(request.date)),
+      date: Value(normalisedDate),
       glasses: Value(request.glasses),
       loggedAt: Value(DateTime.parse(request.loggedAt)),
       synced: const Value(true),

--- a/backend/test/routes/log/meds_test.dart
+++ b/backend/test/routes/log/meds_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:drift/native.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sorgvry_backend/middleware/auth.dart';
+import 'package:sorgvry_shared/sorgvry_shared.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/log/meds.dart' as route;
+
+class _MockRequestContext extends Mock implements RequestContext {}
+
+class _MockRequest extends Mock implements Request {}
+
+void main() {
+  late SorgvryDatabase db;
+  const deviceId = 'test-device-001';
+
+  setUp(() {
+    db = SorgvryDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  RequestContext buildContext(Map<String, dynamic> body) {
+    final ctx = _MockRequestContext();
+    final request = _MockRequest();
+
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(() => request.json()).thenAnswer((_) async => body);
+    when(() => ctx.request).thenReturn(request);
+    when(() => ctx.read<SorgvryDatabase>()).thenReturn(db);
+    when(
+      () => ctx.read<AuthenticatedDeviceId>(),
+    ).thenReturn(const AuthenticatedDeviceId(deviceId));
+
+    return ctx;
+  }
+
+  group('POST /log/meds', () {
+    test('normalises date to UTC midnight', () async {
+      final ctx = buildContext({
+        'deviceId': deviceId,
+        'date': '2026-03-30',
+        'session': 'night',
+        'taken': true,
+        'loggedAt': '2026-03-30T20:00:00',
+      });
+
+      final response = await route.onRequest(ctx);
+      expect(response.statusCode, HttpStatus.ok);
+
+      final rows = await db.select(db.medLogs).get();
+      expect(rows, hasLength(1));
+      // Drift stores as Unix timestamp; convert back to UTC to verify.
+      final storedDate = rows.first.date.toUtc();
+      expect(storedDate, DateTime.utc(2026, 3, 30));
+    });
+
+    test('upserts by deviceId + date + session', () async {
+      // Insert first.
+      var ctx = buildContext({
+        'deviceId': deviceId,
+        'date': '2026-03-30',
+        'session': 'morning',
+        'taken': false,
+        'loggedAt': '2026-03-30T07:00:00',
+      });
+      await route.onRequest(ctx);
+
+      // Upsert same key with updated value.
+      ctx = buildContext({
+        'deviceId': deviceId,
+        'date': '2026-03-30',
+        'session': 'morning',
+        'taken': true,
+        'loggedAt': '2026-03-30T07:30:00',
+      });
+      await route.onRequest(ctx);
+
+      final rows = await db.select(db.medLogs).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.taken, isTrue);
+    });
+
+    test('rejects non-POST methods', () async {
+      final ctx = _MockRequestContext();
+      final request = _MockRequest();
+      when(() => request.method).thenReturn(HttpMethod.get);
+      when(() => ctx.request).thenReturn(request);
+
+      final response = await route.onRequest(ctx);
+      expect(response.statusCode, HttpStatus.methodNotAllowed);
+    });
+
+    test('returns 400 for invalid JSON', () async {
+      final ctx = _MockRequestContext();
+      final request = _MockRequest();
+      when(() => request.method).thenReturn(HttpMethod.post);
+      when(() => request.json()).thenAnswer(
+        (_) async => <String, dynamic>{
+          'bad': 'data',
+        },
+      );
+      when(() => ctx.request).thenReturn(request);
+      when(() => ctx.read<SorgvryDatabase>()).thenReturn(db);
+      when(
+        () => ctx.read<AuthenticatedDeviceId>(),
+      ).thenReturn(const AuthenticatedDeviceId(deviceId));
+
+      final response = await route.onRequest(ctx);
+      expect(response.statusCode, HttpStatus.badRequest);
+    });
+  });
+}

--- a/backend/test/routes/summary_test.dart
+++ b/backend/test/routes/summary_test.dart
@@ -233,7 +233,7 @@ void main() {
               date: Value(date),
               session: const Value('morning'),
               taken: const Value(true),
-              loggedAt: Value(DateTime.utc(2026, 4, 1, 7, 0)),
+              loggedAt: Value(DateTime.utc(2026, 4, 1, 7)),
               synced: const Value(true),
             ),
           );


### PR DESCRIPTION
## Summary
- Normalise `date` field to UTC midnight in all 4 `/log/*` backend endpoints (meds, bp, water, walk)
- `DateTime.parse()` created local-time midnight on the SAST Pi (UTC+2), causing upsert key mismatches that left records stuck in the sync queue
- Same fix pattern as v0.5.1 summary endpoint — now applied consistently across all log endpoints
- Added test for meds endpoint verifying UTC normalisation and upsert behaviour

closes #19

## Test plan
- [x] `dart test` — all 17 backend tests pass
- [x] `dart analyze` — no issues in source files
- [ ] Deploy and verify stuck meds record syncs on next attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)